### PR TITLE
Board implementation - improvement and implementation of Rali's changes

### DIFF
--- a/lib/board_implementation/CFBoard.cpp
+++ b/lib/board_implementation/CFBoard.cpp
@@ -18,15 +18,15 @@ std::string CFBoard::toFEN() {
 // ========== Methods after this comment are implemented ==========
 
 CFBoard::CFBoard() { //This is just the starter board.
-    pawnBoard = (((one << 8) - 1) << 48) + (((one << 8) - 1) << 8);
-    knightBoard = (one << 1) + (one << 6) + (one << 57) + (one << 62);
-    bishopBoard = (one << 2) + (one << 5) + (one << 58) + (one << 61);
-    rookBoard = (one << 0) + (one << 7) + (one << 56) + (one << 63);
-    queenBoard = (one << 3) + (one << 59);
-    kingBoard = (one << 4) + (one << 60);
+    pawnBoard = (((1ll << 8) - 1) << 48) + (((1ll << 8) - 1) << 8);
+    knightBoard = (1ll << 1) + (1ll << 6) + (1ll << 57) + (1ll << 62);
+    bishopBoard = (1ll << 2) + (1ll << 5) + (1ll << 58) + (1ll << 61);
+    rookBoard = (1ll << 0) + (1ll << 7) + (1ll << 56) + (1ll << 63);
+    queenBoard = (1ll << 3) + (1ll << 59);
+    kingBoard = (1ll << 4) + (1ll << 60);
 
-    whiteBoard = ((one << 16) - 1) << 48;
-    blackBoard = (one << 16) - 1;
+    whiteBoard = ((1ll << 16) - 1) << 48;
+    blackBoard = (1ll << 16) - 1;
 
     turn = 0;
 }
@@ -108,7 +108,7 @@ uint64_t& CFBoard::getPieceBoardFromIndex(int boardIndex) {
 }
 
 void CFBoard::addPiece(int pieceId, int tile) {
-    uint64_t pieceBoard = one << tile;
+    uint64_t pieceBoard = 1ll << tile;
     removePiece(tile);
 
     int pieceType = pieceId >> 1;
@@ -125,7 +125,7 @@ void CFBoard::addPiece(int pieceId, int tile) {
     }
 }
 void CFBoard::removePiece(int tile) {
-    uint64_t antiPieceBoard = ~(one << tile);
+    uint64_t antiPieceBoard = ~(1ll << tile);
 
     for (int pieceType = 0; pieceType < 6; pieceType++) {
         uint64_t& targetBoard = getPieceBoardFromIndex(pieceType);

--- a/lib/board_implementation/CFBoard.h
+++ b/lib/board_implementation/CFBoard.h
@@ -25,8 +25,8 @@ public:
 	// ----- get functions -----
 
 	/**
-  * obsolete - kept for reference
-  *
+	* obsolete - kept for reference
+	*
 	* @brief Returns a copy of the bitboard associated to the input piece type.
 	*
 	* @param pieceType : a character like "P", "K", "N"...
@@ -67,9 +67,9 @@ private:
 	uint64_t pawnBoard;
 	uint64_t knightBoard;
 	uint64_t bishopBoard;
-  uint64_t rookBoard;
+	uint64_t rookBoard;
 	uint64_t queenBoard;
-  uint64_t kingBoard;
+	uint64_t kingBoard;
 
 	//TODO reduce both of these to the smallest int types
 	int enPassantTarget; //a single coordinate from 0-63 

--- a/lib/board_implementation/CFBoard.h
+++ b/lib/board_implementation/CFBoard.h
@@ -44,8 +44,6 @@ public:
 	*/
 
 private:
-	uint64_t one = 1;
-
 	uint64_t PawnBoard;
 	uint64_t KingBoard;
 	uint64_t QueenBoard;
@@ -57,6 +55,9 @@ private:
 	uint64_t WhiteBoard;
 
 	bool turn; // 0 for white, 1 for black
+
+	int castleBools;
+	int enPassantTarget;
 
 	/*
 		a8 = 2^0

--- a/lib/board_implementation/CFBoard.h
+++ b/lib/board_implementation/CFBoard.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <iostream>
+#include <stdint.h>
+
 class CFBoard {
 public:
 
@@ -10,7 +13,7 @@ public:
 	std::string getRepr();
 	std::string toFEN(); // TO DO
 
-	void addPiece(char pieceType, bool color, int tile); // pieceType in P,R,N,B,Q,K and 0<=tile<=63. Function replaces existing piece on the tile.
+	void addPiece(int pieceId, int tile); // pieceType in P,R,N,B,Q,K and 0<=tile<=63. Function replaces existing piece on the tile.
 	void removePiece(int tile);
 
 	// ----- formatting functions -----
@@ -20,11 +23,14 @@ public:
 
 	// ----- get functions -----
 
-	bool getBit(char pieceType, bool color, int tile);
+	bool getBit(int pieceId, int tile);
+
+	uint64_t& getPieceBoardFromIndex(int boardIndex);
 
 	// these create a copy
-	uint64_t getPieceBitBoard(char pieceType);
+
 	uint64_t getColorBitBoard(bool color);
+	uint64_t getPieceColorBitBoard(int pieceId);
 
 	int getPieceFromCoords(int tile); // output is [0,1,2,3,4,5]+(color)
 	
@@ -44,15 +50,15 @@ public:
 	*/
 
 private:
-	uint64_t PawnBoard;
-	uint64_t KingBoard;
-	uint64_t QueenBoard;
-	uint64_t RookBoard;
-	uint64_t KnightBoard;
-	uint64_t BishopBoard;
+	uint64_t pawnBoard;
+	uint64_t kingBoard;
+	uint64_t queenBoard;
+	uint64_t rookBoard;
+	uint64_t knightBoard;
+	uint64_t bishopBoard;
 
-	uint64_t BlackBoard;
-	uint64_t WhiteBoard;
+	uint64_t blackBoard;
+	uint64_t whiteBoard;
 
 	bool turn; // 0 for white, 1 for black
 

--- a/lib/board_implementation/CFBoard.h
+++ b/lib/board_implementation/CFBoard.h
@@ -4,27 +4,33 @@ class CFBoard {
 public:
 
 	CFBoard();
+	CFBoard(std::string FEN) : CFBoard() { fromFEN(FEN); } // TO DO
+	void fromFEN(std::string FEN); // TO DO
+
+	std::string getRepr();
+	std::string toFEN(); // TO DO
 
 	void addPiece(char pieceType, bool color, int tile); // pieceType in P,R,N,B,Q,K and 0<=tile<=63. Function replaces existing piece on the tile.
 	void removePiece(int tile);
-	//void naiveMovePiece(int starttile, int endtile);
+
+	// ----- formatting functions -----
+	char pieceIdToChar(int pieceId);
+	bool pieceIdToColor(int pieceId);
+	int pieceCharColorToId(char pieceChar, bool color);
+
+	// ----- get functions -----
 
 	bool getBit(char pieceType, bool color, int tile);
 
-	// these create a copy (I think)
+	// these create a copy
 	uint64_t getPieceBitBoard(char pieceType);
 	uint64_t getColorBitBoard(bool color);
 
-	std::string getRepr();
-
-	// Sirawit, 27/11/2022: I'm not sure we're going to implement this or not, but it would be really good for the switch part if we can do this
-	CFBoard(std::string FEN) : CFBoard() { fromFEN(FEN); }
-	void fromFEN(std::string FEN);
-	std::string toFEN();
-	// End (Sirawit, 27/11/2022)
-
+	int getPieceFromCoords(int tile); // output is [0,1,2,3,4,5]+(color)
+	
 
 	/*
+	void naiveMovePiece(int starttile, int endtile);
 	uint64_t getCardinals(int tile, bool color);
 	uint64_t getDiagonals(int tile, bool color);
 


### PR DESCRIPTION
Improved code and reimplemented Rali's QoL changes:
- Changed the way piece types are handled within the class from `char`s to `int`s. This makes it possible to iterate over piece types without using a switch statement, which is more readable.
- Changed the order in which the bitboards are initiated in the class declaration to be the same order in which the pieces iterate (readability).
- Similarly made it possible to iterate over the piece bitboards by assigning them their piece type ID. (This uses a switch statement but it is now in a callable method instead of copy pasted everywhere).
- Added and removed methods accordingly.
- Blocked together already implemented methods at the end of the .cpp file to improve readability.
Rali's QoL changes:
- renamed bitboards into camelCase (e.g. `PawnBoard` -> `pawnBoard`).
- changed instances of `uint64_t one = 1;` into using `1ll` instead.
- Kept Rali's sample docstring (now describes a nonexistent function and only serves purpose as a reference).